### PR TITLE
Adding video publishDate

### DIFF
--- a/lib/src/playlists/playlist_client.dart
+++ b/lib/src/playlists/playlist_client.dart
@@ -46,12 +46,16 @@ class PlaylistClient {
           continue;
         }
 
+        var videoInfoResponse =
+            await VideoInfoResponse.get(_httpClient, videoId);
+
         yield Video(
             VideoId(videoId),
             video.title,
             video.author,
             video.channelId,
             video.uploadDate,
+            videoInfoResponse.playerResponse.videoPublishDate,
             video.description,
             video.duration,
             ThumbnailSet(videoId),

--- a/lib/src/reverse_engineering/responses/player_response.dart
+++ b/lib/src/reverse_engineering/responses/player_response.dart
@@ -36,6 +36,10 @@ class PlayerResponse {
       _root['microformat']['playerMicroformatRenderer']['uploadDate']);
 
   ///
+  DateTime get videoPublishDate => DateTime.parse(
+      _root['microformat']['playerMicroformatRenderer']['publishDate']);
+
+  ///
   String get videoChannelId => _root['videoDetails']['channelId'];
 
   ///

--- a/lib/src/search/search_client.dart
+++ b/lib/src/search/search_client.dart
@@ -1,3 +1,5 @@
+import 'package:youtube_explode_dart/src/reverse_engineering/responses/responses.dart';
+
 import '../common/common.dart';
 import '../reverse_engineering/responses/playlist_response.dart';
 import '../reverse_engineering/youtube_http_client.dart';
@@ -28,12 +30,16 @@ class SearchClient {
           continue;
         }
 
+        var videoInfoResponse =
+            await VideoInfoResponse.get(_httpClient, videoId);
+
         yield Video(
             VideoId(videoId),
             video.title,
             video.author,
             video.channelId,
             video.uploadDate,
+            videoInfoResponse.playerResponse.videoPublishDate,
             video.description,
             video.duration,
             ThumbnailSet(videoId),

--- a/lib/src/videos/video.dart
+++ b/lib/src/videos/video.dart
@@ -27,6 +27,9 @@ class Video with EquatableMixin {
   /// Video upload date.
   final DateTime uploadDate;
 
+  /// Video publish date.
+  final DateTime publishDate;
+
   /// Video description.
   final String description;
 
@@ -56,6 +59,7 @@ class Video with EquatableMixin {
       this.author,
       this.channelId,
       this.uploadDate,
+      this.publishDate,
       this.description,
       this.duration,
       this.thumbnails,

--- a/lib/src/videos/video_client.dart
+++ b/lib/src/videos/video_client.dart
@@ -39,6 +39,7 @@ class VideoClient {
         playerResponse.videoAuthor,
         ChannelId(playerResponse.videoChannelId),
         playerResponse.videoUploadDate,
+        playerResponse.videoPublishDate,
         playerResponse.videoDescription,
         playerResponse.videoDuration,
         ThumbnailSet(videoId.value),
@@ -57,12 +58,15 @@ class VideoClient {
       throw TransientFailureException('Video not found in mix playlist');
     }
 
+    var videoInfoResponse = await VideoInfoResponse.get(_httpClient, id.value);
+
     return Video(
         id,
         video.title,
         video.author,
         video.channelId,
         video.uploadDate,
+        videoInfoResponse.playerResponse.videoPublishDate,
         video.description,
         video.duration,
         ThumbnailSet(id.value),


### PR DESCRIPTION
Resolves https://github.com/Hexer10/youtube_explode_dart/issues/68

From the tests I've done, all publishDates we receive are set to midnight of the actual publish date (i.e. date only, no time), even if they were published at different times. The correct date is still valuable even if the time isn't available.