### PR TITLE
fix: Fix long playlist extraction again

### DIFF
--- a/lib/src/reverse_engineering/responses/playlist_page.dart
+++ b/lib/src/reverse_engineering/responses/playlist_page.dart
@@ -52,7 +52,7 @@ class PlaylistPage {
       {String? token}) {
     if (token != null && token.isNotEmpty) {
       var url =
-          'https://www.youtube.com/youtubei/v1/guide?key=AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8';
+          'https://www.youtube.com/youtubei/v1/browse?key=AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8';
 
       return retry(() async {
         var body = {


### PR DESCRIPTION
YouTube changed their API endpoint AGAIN or my browser had a older version still in cache.
This changes it to the new endpoint again.