### PR TITLE
#180 Fixed

### DIFF
--- a/lib/src/reverse_engineering/clients/embedded_player_client.dart
+++ b/lib/src/reverse_engineering/clients/embedded_player_client.dart
@@ -53,9 +53,8 @@ class EmbeddedPlayerClient {
       'context': const {
         'client': {
           'hl': 'en',
-          'clientName': 'WEB',
-          'clientVersion': '2.20210721.00.00',
-          "clientScreen": "EMBED"
+          'clientName': 'ANDROID',
+          'clientVersion': '16.46.37'
         }
       },
       'videoId': videoId

--- a/lib/src/videos/streams/streams_client.dart
+++ b/lib/src/videos/streams/streams_client.dart
@@ -198,13 +198,13 @@ class StreamsClient {
     videoId = VideoId.fromString(videoId);
 
     try {
-      final context = await _getStreamContextFromWatchPage(videoId);
+      final context = await _getStreamContextFromEmbeddedClient(videoId);
       return _getManifest(context);
     } on YoutubeExplodeException {
       //TODO: ignore
     }
+    final context = await _getStreamContextFromWatchPage(videoId);
 
-    final context = await _getStreamContextFromEmbeddedClient(videoId);
     return _getManifest(context);
   }
 


### PR DESCRIPTION
This fixes #180 

To fix this issue I have first swapped the _getStreamContextFromEmbeddedClient and _getStreamContextFromWatchPage. So as the first attempt should be made from the embedded client. Then I changed the client in EmbeddedPlayerClient.get() to 'ANDROID"  like it's in [this](https://github.com/Tyrrrz/YoutubeExplode/commit/4bdbbf23939db45dd19fba396389527fa3cde857) commit.

