### PR TITLE
Added field 'uploadDateRaw' on Video model

### DIFF
--- a/lib/src/channels/channel_client.dart
+++ b/lib/src/channels/channel_client.dart
@@ -24,8 +24,13 @@ class ChannelClient {
     id = ChannelId.fromString(id);
     var channelPage = await ChannelPage.get(_httpClient, id.value);
 
-    return Channel(id, channelPage.channelTitle, channelPage.channelLogoUrl,
-        channelPage.channelBannerUrl, channelPage.subscribersCount);
+    return Channel(
+      id,
+      channelPage.channelTitle,
+      channelPage.channelLogoUrl,
+      channelPage.channelBannerUrl,
+      channelPage.subscribersCount,
+    );
   }
 
   /// Gets the metadata associated with the channel of the specified user.
@@ -34,14 +39,14 @@ class ChannelClient {
   Future<Channel> getByUsername(dynamic username) async {
     username = Username.fromString(username);
 
-    var channelPage = await ChannelPage.getByUsername(
-        _httpClient, (username as Username).value);
+    var channelPage = await ChannelPage.getByUsername(_httpClient, (username as Username).value);
     return Channel(
-        ChannelId(channelPage.channelId),
-        channelPage.channelTitle,
-        channelPage.channelLogoUrl,
-        channelPage.channelBannerUrl,
-        channelPage.subscribersCount);
+      ChannelId(channelPage.channelId),
+      channelPage.channelTitle,
+      channelPage.channelLogoUrl,
+      channelPage.channelBannerUrl,
+      channelPage.subscribersCount,
+    );
   }
 
   /// Gets the info found on a YouTube Channel About page.
@@ -53,16 +58,14 @@ class ChannelClient {
     final aboutPage = await ChannelAboutPage.get(_httpClient, channelId.value);
 
     return ChannelAbout(
-        aboutPage.description,
-        aboutPage.viewCount,
-        aboutPage.joinDate,
-        aboutPage.title,
-        [
-          for (var e in aboutPage.avatar)
-            Thumbnail(Uri.parse(e['url']), e['height'], e['width'])
-        ],
-        aboutPage.country,
-        aboutPage.channelLinks);
+      aboutPage.description,
+      aboutPage.viewCount,
+      aboutPage.joinDate,
+      aboutPage.title,
+      [for (var e in aboutPage.avatar) Thumbnail(Uri.parse(e['url']), e['height'], e['width'])],
+      aboutPage.country,
+      aboutPage.channelLinks,
+    );
   }
 
   /// Gets the info found on a YouTube Channel About page.
@@ -71,20 +74,17 @@ class ChannelClient {
   Future<ChannelAbout> getAboutPageByUsername(dynamic username) async {
     username = Username.fromString(username);
 
-    var page =
-        await ChannelAboutPage.getByUsername(_httpClient, username.value);
+    var page = await ChannelAboutPage.getByUsername(_httpClient, username.value);
 
     return ChannelAbout(
-        page.description,
-        page.viewCount,
-        page.joinDate,
-        page.title,
-        [
-          for (var e in page.avatar)
-            Thumbnail(Uri.parse(e['url']), e['height'], e['width'])
-        ],
-        page.country,
-        page.channelLinks);
+      page.description,
+      page.viewCount,
+      page.joinDate,
+      page.title,
+      [for (var e in page.avatar) Thumbnail(Uri.parse(e['url']), e['height'], e['width'])],
+      page.country,
+      page.channelLinks,
+    );
   }
 
   /// Gets the metadata associated with the channel
@@ -113,29 +113,29 @@ class ChannelClient {
   ///
   /// Note that this endpoint provides less info about each video
   /// (only the Title and VideoId).
-  Future<ChannelUploadsList> getUploadsFromPage(dynamic channelId,
-      [VideoSorting videoSorting = VideoSorting.newest]) async {
+  Future<ChannelUploadsList> getUploadsFromPage(dynamic channelId, [VideoSorting videoSorting = VideoSorting.newest]) async {
     channelId = ChannelId.fromString(channelId);
-    final page = await ChannelUploadPage.get(
-        _httpClient, (channelId as ChannelId).value, videoSorting.code);
+    final page = await ChannelUploadPage.get(_httpClient, (channelId as ChannelId).value, videoSorting.code);
 
     final channel = await get(channelId);
 
     return ChannelUploadsList(
         page.uploads
             .map((e) => Video(
-                e.videoId,
-                e.videoTitle,
-                channel.title,
-                channelId,
-                e.videoUploadDate.toDateTime(),
-                null,
-                '',
-                e.videoDuration,
-                ThumbnailSet(e.videoId.value),
-                null,
-                Engagement(e.videoViews, null, null),
-                false))
+                  e.videoId,
+                  e.videoTitle,
+                  channel.title,
+                  channelId,
+                  e.videoUploadDate.toDateTime(),
+                  e.videoUploadDate,
+                  null,
+                  '',
+                  e.videoDuration,
+                  ThumbnailSet(e.videoId.value),
+                  null,
+                  Engagement(e.videoViews, null, null),
+                  false,
+                ))
             .toList(),
         channel.title,
         channelId,

--- a/lib/src/channels/channel_uploads_list.dart
+++ b/lib/src/channels/channel_uploads_list.dart
@@ -17,9 +17,7 @@ class ChannelUploadsList extends DelegatingList<Video> {
 
   /// Construct an instance of [SearchList]
   /// See [SearchList]
-  ChannelUploadsList(
-      List<Video> base, this.author, this.channel, this._page, this._httpClient)
-      : super(base);
+  ChannelUploadsList(List<Video> base, this.author, this.channel, this._page, this._httpClient) : super(base);
 
   /// Fetches the next batch of videos or returns null if there are no more
   /// results.
@@ -31,18 +29,20 @@ class ChannelUploadsList extends DelegatingList<Video> {
     return ChannelUploadsList(
         page.uploads
             .map((e) => Video(
-                e.videoId,
-                e.videoTitle,
-                author,
-                channel,
-                e.videoUploadDate.toDateTime(),
-                null,
-                '',
-                e.videoDuration,
-                ThumbnailSet(e.videoId.value),
-                null,
-                Engagement(e.videoViews, null, null),
-                false))
+                  e.videoId,
+                  e.videoTitle,
+                  author,
+                  channel,
+                  e.videoUploadDate.toDateTime(),
+                  e.videoUploadDate,
+                  null,
+                  '',
+                  e.videoDuration,
+                  ThumbnailSet(e.videoId.value),
+                  null,
+                  Engagement(e.videoViews, null, null),
+                  false,
+                ))
             .toList(),
         author,
         channel,

--- a/lib/src/playlists/playlist_client.dart
+++ b/lib/src/playlists/playlist_client.dart
@@ -18,16 +18,16 @@ class PlaylistClient {
   Future<Playlist> get(dynamic id) async {
     id = PlaylistId.fromString(id);
 
-    var response =
-        await PlaylistPage.get(_httpClient, (id as PlaylistId).value);
+    var response = await PlaylistPage.get(_httpClient, (id as PlaylistId).value);
     return Playlist(
-        id,
-        response.title ?? '',
-        response.author ?? '',
-        response.description ?? '',
-        ThumbnailSet(id.value),
-        Engagement(response.viewCount ?? 0, null, null),
-        response.videoCount);
+      id,
+      response.title ?? '',
+      response.author ?? '',
+      response.description ?? '',
+      ThumbnailSet(id.value),
+      Engagement(response.viewCount ?? 0, null, null),
+      response.videoCount,
+    );
   }
 
   /// Enumerates videos included in the specified playlist.
@@ -51,18 +51,20 @@ class PlaylistClient {
         }
 
         yield Video(
-            VideoId(videoId),
-            video.title,
-            video.author,
-            ChannelId(video.channelId),
-            null,
-            null,
-            video.description,
-            video.duration,
-            ThumbnailSet(videoId),
-            null,
-            Engagement(video.viewCount, null, null),
-            false);
+          VideoId(videoId),
+          video.title,
+          video.author,
+          ChannelId(video.channelId),
+          null,
+          null,
+          null,
+          video.description,
+          video.duration,
+          ThumbnailSet(videoId),
+          null,
+          Engagement(video.viewCount, null, null),
+          false,
+        );
       }
       page = await page.nextPage(_httpClient);
     }

--- a/lib/src/search/search_client.dart
+++ b/lib/src/search/search_client.dart
@@ -15,42 +15,27 @@ class SearchClient {
   /// (from the video search page).
   /// The videos are sent in batch of 20 videos.
   /// You [VideoSearchList.nextPage] to get the next batch of videos.
-  Future<VideoSearchList> search(String searchQuery,
-      {SearchFilter filter = TypeFilters.video}) async {
+  Future<VideoSearchList> search(String searchQuery, {SearchFilter filter = TypeFilters.video}) async {
     final page = await SearchPage.get(_httpClient, searchQuery, filter: filter);
 
     return VideoSearchList(
         page.searchContent
             .whereType<SearchVideo>()
-            .map((e) => Video(
-                e.id,
-                e.title,
-                e.author,
-                ChannelId(e.channelId),
-                e.uploadDate?.toDateTime(),
-                null,
-                e.description,
-                e.duration.toDuration(),
-                ThumbnailSet(e.id.value),
-                null,
-                Engagement(e.viewCount, null, null),
-                e.isLive))
+            .map((e) => Video(e.id, e.title, e.author, ChannelId(e.channelId), e.uploadDate?.toDateTime(), e.uploadDate?.toString(), null,
+                e.description, e.duration.toDuration(), ThumbnailSet(e.id.value), null, Engagement(e.viewCount, null, null), e.isLive))
             .toList(),
         page,
         _httpClient);
   }
 
   @Deprecated('Use SearchClient.search')
-  Future<VideoSearchList> getVideos(String searchQuery,
-          {SearchFilter filter = TypeFilters.video}) =>
-      search(searchQuery, filter: filter);
+  Future<VideoSearchList> getVideos(String searchQuery, {SearchFilter filter = TypeFilters.video}) => search(searchQuery, filter: filter);
 
   /// Enumerates results returned by the specified search query.
   /// The contents are sent in batch of 20 elements.
   /// The list can either contain a [SearchVideo], [SearchPlaylist] or a [SearchChannel].
   /// You [SearchList.nextPage] to get the next batch of content.
-  Future<SearchList> searchContent(String searchQuery,
-      {SearchFilter filter = const SearchFilter('')}) async {
+  Future<SearchList> searchContent(String searchQuery, {SearchFilter filter = const SearchFilter('')}) async {
     final page = await SearchPage.get(_httpClient, searchQuery, filter: filter);
 
     return SearchList(page.searchContent, page, _httpClient);
@@ -61,14 +46,12 @@ class SearchClient {
   /// The list can either contain a [SearchVideo], [SearchPlaylist] or a [SearchChannel].
   /// You [SearchList.nextPage] to get the next batch of content.
   /// Same as [SearchClient.search]
-  Future<VideoSearchList> call(String searchQuery,
-          {SearchFilter filter = const SearchFilter('')}) async =>
-      search(searchQuery, filter: filter);
+  Future<VideoSearchList> call(String searchQuery, {SearchFilter filter = const SearchFilter('')}) async => search(searchQuery, filter: filter);
 
   /// Returns the suggestions youtube provide while search on the page.
   Future<List<String>> getQuerySuggestions(String query) async {
-    final request = await _httpClient.get(
-        'https://suggestqueries-clients6.youtube.com/complete/search?client=youtube&hl=en&gl=en&q=${Uri.encodeComponent(query)}&callback=func');
+    final request = await _httpClient
+        .get('https://suggestqueries-clients6.youtube.com/complete/search?client=youtube&hl=en&gl=en&q=${Uri.encodeComponent(query)}&callback=func');
     final body = request.body;
     final startIndex = body.indexOf('func(');
     final jsonStr = body.substring(startIndex + 5, body.length - 1);
@@ -80,12 +63,9 @@ class SearchClient {
   /// Queries to YouTube to get the results.
   /// You need to manually read [SearchQuery.content] and/or [SearchQuery.relatedVideos].
   /// For most cases [SearchClient.search] is enough.
-  Future<SearchQuery> searchRaw(String searchQuery,
-          {SearchFilter filter = const SearchFilter('')}) =>
+  Future<SearchQuery> searchRaw(String searchQuery, {SearchFilter filter = const SearchFilter('')}) =>
       SearchQuery.search(_httpClient, searchQuery, filter: filter);
 
   @Deprecated('Use searchRaw')
-  Future<SearchQuery> queryFromPage(String searchQuery,
-          {SearchFilter filter = const SearchFilter('')}) =>
-      searchRaw(searchQuery, filter: filter);
+  Future<SearchQuery> queryFromPage(String searchQuery, {SearchFilter filter = const SearchFilter('')}) => searchRaw(searchQuery, filter: filter);
 }

--- a/lib/src/search/search_list.dart
+++ b/lib/src/search/search_list.dart
@@ -49,18 +49,20 @@ class VideoSearchList extends DelegatingList<Video> {
         page.searchContent
             .whereType<SearchVideo>()
             .map((e) => Video(
-                e.id,
-                e.title,
-                e.author,
-                ChannelId(e.channelId),
-                e.uploadDate.toDateTime(),
-                null,
-                e.description,
-                e.duration.toDuration(),
-                ThumbnailSet(e.id.value),
-                null,
-                Engagement(e.viewCount, null, null),
-                e.isLive))
+                  e.id,
+                  e.title,
+                  e.author,
+                  ChannelId(e.channelId),
+                  e.uploadDate.toDateTime(),
+                  e.uploadDate,
+                  null,
+                  e.description,
+                  e.duration.toDuration(),
+                  ThumbnailSet(e.id.value),
+                  null,
+                  Engagement(e.viewCount, null, null),
+                  e.isLive,
+                ))
             .toList(),
         page,
         _httpClient);

--- a/lib/src/videos/video.dart
+++ b/lib/src/videos/video.dart
@@ -34,6 +34,7 @@ class Video with _$Video {
       /// Note: For search queries it is calculated with:
       ///   DateTime.now() - how much time is was published.
       DateTime? uploadDate,
+      String? uploadDateRaw,
 
       /// Video publish date.
       DateTime? publishDate,
@@ -79,6 +80,7 @@ class Video with _$Video {
         /// Note: For search queries it is calculated with:
         ///   DateTime.now() - how much time is was published.
         uploadDate,
+        uploadDateRaw,
 
         /// Video publish date.
         publishDate,
@@ -110,6 +112,7 @@ class Video with _$Video {
       /// Note: For search queries it is calculated with:
       ///   DateTime.now() - how much time is was published.
       DateTime? uploadDate,
+      String? uploadDateRaw,
 
       /// Video publish date.
       DateTime? publishDate,

--- a/lib/src/videos/video.freezed.dart
+++ b/lib/src/videos/video.freezed.dart
@@ -24,6 +24,7 @@ class _$VideoTearOff {
       String author,
       ChannelId channelId,
       DateTime? uploadDate,
+      String? uploadDateRaw,
       DateTime? publishDate,
       String description,
       Duration? duration,
@@ -38,6 +39,7 @@ class _$VideoTearOff {
       author,
       channelId,
       uploadDate,
+      uploadDateRaw,
       publishDate,
       description,
       duration,
@@ -71,6 +73,7 @@ mixin _$Video {
   /// Note: For search queries it is calculated with:
   ///   DateTime.now() - how much time is was published.
   DateTime? get uploadDate => throw _privateConstructorUsedError;
+  String? get uploadDateRaw => throw _privateConstructorUsedError;
 
   /// Video publish date.
   DateTime? get publishDate => throw _privateConstructorUsedError;
@@ -114,6 +117,7 @@ abstract class $VideoCopyWith<$Res> {
       String author,
       ChannelId channelId,
       DateTime? uploadDate,
+      String? uploadDateRaw,
       DateTime? publishDate,
       String description,
       Duration? duration,
@@ -144,6 +148,7 @@ class _$VideoCopyWithImpl<$Res> implements $VideoCopyWith<$Res> {
     Object? author = freezed,
     Object? channelId = freezed,
     Object? uploadDate = freezed,
+    Object? uploadDateRaw = freezed,
     Object? publishDate = freezed,
     Object? description = freezed,
     Object? duration = freezed,
@@ -174,6 +179,10 @@ class _$VideoCopyWithImpl<$Res> implements $VideoCopyWith<$Res> {
           ? _value.uploadDate
           : uploadDate // ignore: cast_nullable_to_non_nullable
               as DateTime?,
+      uploadDateRaw: uploadDateRaw == freezed
+          ? _value.uploadDateRaw
+          : uploadDateRaw // ignore: cast_nullable_to_non_nullable
+              as String?,
       publishDate: publishDate == freezed
           ? _value.publishDate
           : publishDate // ignore: cast_nullable_to_non_nullable
@@ -249,6 +258,7 @@ abstract class _$VideoCopyWith<$Res> implements $VideoCopyWith<$Res> {
       String author,
       ChannelId channelId,
       DateTime? uploadDate,
+      String? uploadDateRaw,
       DateTime? publishDate,
       String description,
       Duration? duration,
@@ -284,6 +294,7 @@ class __$VideoCopyWithImpl<$Res> extends _$VideoCopyWithImpl<$Res>
     Object? author = freezed,
     Object? channelId = freezed,
     Object? uploadDate = freezed,
+    Object? uploadDateRaw = freezed,
     Object? publishDate = freezed,
     Object? description = freezed,
     Object? duration = freezed,
@@ -314,6 +325,10 @@ class __$VideoCopyWithImpl<$Res> extends _$VideoCopyWithImpl<$Res>
           ? _value.uploadDate
           : uploadDate // ignore: cast_nullable_to_non_nullable
               as DateTime?,
+      uploadDateRaw == freezed
+          ? _value.uploadDateRaw
+          : uploadDateRaw // ignore: cast_nullable_to_non_nullable
+              as String?,
       publishDate == freezed
           ? _value.publishDate
           : publishDate // ignore: cast_nullable_to_non_nullable
@@ -359,6 +374,7 @@ class _$_Video extends _Video {
       this.author,
       this.channelId,
       this.uploadDate,
+      this.uploadDateRaw,
       this.publishDate,
       this.description,
       this.duration,
@@ -391,6 +407,8 @@ class _$_Video extends _Video {
   /// Note: For search queries it is calculated with:
   ///   DateTime.now() - how much time is was published.
   final DateTime? uploadDate;
+  @override
+  final String? uploadDateRaw;
   @override
 
   /// Video publish date.
@@ -429,7 +447,7 @@ class _$_Video extends _Video {
 
   @override
   String toString() {
-    return 'Video._internal(id: $id, title: $title, author: $author, channelId: $channelId, uploadDate: $uploadDate, publishDate: $publishDate, description: $description, duration: $duration, thumbnails: $thumbnails, keywords: $keywords, engagement: $engagement, isLive: $isLive, watchPage: $watchPage)';
+    return 'Video._internal(id: $id, title: $title, author: $author, channelId: $channelId, uploadDate: $uploadDate, uploadDateRaw: $uploadDateRaw, publishDate: $publishDate, description: $description, duration: $duration, thumbnails: $thumbnails, keywords: $keywords, engagement: $engagement, isLive: $isLive, watchPage: $watchPage)';
   }
 
   @override
@@ -443,6 +461,8 @@ class _$_Video extends _Video {
             const DeepCollectionEquality().equals(other.channelId, channelId) &&
             const DeepCollectionEquality()
                 .equals(other.uploadDate, uploadDate) &&
+            const DeepCollectionEquality()
+                .equals(other.uploadDateRaw, uploadDateRaw) &&
             const DeepCollectionEquality()
                 .equals(other.publishDate, publishDate) &&
             const DeepCollectionEquality()
@@ -465,6 +485,7 @@ class _$_Video extends _Video {
       const DeepCollectionEquality().hash(author),
       const DeepCollectionEquality().hash(channelId),
       const DeepCollectionEquality().hash(uploadDate),
+      const DeepCollectionEquality().hash(uploadDateRaw),
       const DeepCollectionEquality().hash(publishDate),
       const DeepCollectionEquality().hash(description),
       const DeepCollectionEquality().hash(duration),
@@ -487,6 +508,7 @@ abstract class _Video extends Video {
       String author,
       ChannelId channelId,
       DateTime? uploadDate,
+      String? uploadDateRaw,
       DateTime? publishDate,
       String description,
       Duration? duration,
@@ -519,6 +541,8 @@ abstract class _Video extends Video {
   /// Note: For search queries it is calculated with:
   ///   DateTime.now() - how much time is was published.
   DateTime? get uploadDate;
+  @override
+  String? get uploadDateRaw;
   @override
 
   /// Video publish date.

--- a/lib/src/videos/video_client.dart
+++ b/lib/src/videos/video_client.dart
@@ -42,27 +42,18 @@ class VideoClient {
         playerResponse.videoTitle,
         playerResponse.videoAuthor,
         ChannelId(playerResponse.videoChannelId),
-        playerResponse.videoUploadDate ??
-            watchPage.root
-                .querySelector('meta[itemprop=uploadDate]')
-                ?.attributes['content']
-                ?.tryParseDateTime(),
-        playerResponse.videoPublishDate ??
-            watchPage.root
-                .querySelector('meta[itemprop=datePublished]')
-                ?.attributes['content']
-                ?.tryParseDateTime(),
+        playerResponse.videoUploadDate ?? watchPage.root.querySelector('meta[itemprop=uploadDate]')?.attributes['content']?.tryParseDateTime(),
+        playerResponse.videoUploadDate.toString(),
+        playerResponse.videoPublishDate ?? watchPage.root.querySelector('meta[itemprop=datePublished]')?.attributes['content']?.tryParseDateTime(),
         playerResponse.videoDescription,
         playerResponse.videoDuration,
         ThumbnailSet(videoId.value),
         playerResponse.videoKeywords,
-        Engagement(playerResponse.videoViewCount, watchPage.videoLikeCount,
-            watchPage.videoDislikeCount),
+        Engagement(playerResponse.videoViewCount, watchPage.videoLikeCount, watchPage.videoDislikeCount),
         playerResponse.isLive,
         watchPage);
   }
 
   /// Get a [Video] instance from a [videoId]
-  Future<Video> get(dynamic videoId) async =>
-      _getVideoFromWatchPage(VideoId.fromString(videoId));
+  Future<Video> get(dynamic videoId) async => _getVideoFromWatchPage(VideoId.fromString(videoId));
 }


### PR DESCRIPTION
This field was added in order to overcome a bug in parsing video upload dates.

When parsing the string 'Streamed 3 weeks ago' to datetime the result is approximatelly calculated, so the final datetime value is not accurate. 
For example:
- Current date: 2022-05-15
- Upload date text: Streamed 3 weeks ago
- Calculated upload datetime: 2022-04-24 18:11:08.553464
- Original upload datetime: Apr 19, 2022

So, since we can't be sure of the exact upload date, I added the field with the original string that's displayed on YouTube.