### PR TITLE
Export BaseSearchContent to users

### DIFF
--- a/lib/src/search/search.dart
+++ b/lib/src/search/search.dart
@@ -9,4 +9,5 @@ export 'search_filter.dart';
 export 'search_list.dart';
 export 'search_playlist.dart';
 export 'search_query.dart';
+export 'base_search_content.dart';
 export 'search_video.dart';


### PR DESCRIPTION
Hi there, thank you for your awesome work!

I would really like you to export 'BaseSearchContent' because it allows me to use that type when forwarding responses through my repository layer without using `dynamic`.