### PR TITLE
Shorts filter added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.0
+- BREAKING CHANGE: 
+    - In `getUploadsFromPage`: the `videoSorting` parameter is now a named parameter
+- Shorts filter possibility added in `getUploadsFromPage`.
+
 ## 2.0.4
 - Fix issue when parsing dates formatted as "Streamed <q> <unit> ago" due to a leading whitespace. #265
 

--- a/lib/src/channels/channel_client.dart
+++ b/lib/src/channels/channel_client.dart
@@ -1,3 +1,5 @@
+import 'video_type.dart';
+
 import '../common/common.dart';
 import '../extensions/helpers_extension.dart';
 import '../playlists/playlists.dart';
@@ -137,14 +139,16 @@ class ChannelClient {
   ///
   /// Use .nextPage() to fetch the next batch of videos.
   Future<ChannelUploadsList> getUploadsFromPage(
-    dynamic channelId, [
+    dynamic channelId, {
     VideoSorting videoSorting = VideoSorting.newest,
-  ]) async {
+    VideoType videoType = VideoType.normal,
+  }) async {
     channelId = ChannelId.fromString(channelId);
     final page = await ChannelUploadPage.get(
       _httpClient,
       (channelId as ChannelId).value,
       videoSorting.code,
+      videoType,
     );
 
     final channel = await get(channelId);

--- a/lib/src/channels/channels.dart
+++ b/lib/src/channels/channels.dart
@@ -13,3 +13,4 @@ export 'channel_uploads_list.dart';
 export 'channel_video.dart';
 export 'username.dart';
 export 'video_sorting.dart';
+export 'video_type.dart';

--- a/lib/src/channels/video_type.dart
+++ b/lib/src/channels/video_type.dart
@@ -1,0 +1,14 @@
+/// The type of the video you want to get.
+///
+/// Will filter only by the type you want.
+enum VideoType {
+  /// Default horizontal video
+  normal('videos', 'videoRenderer'),
+
+  /// Youtube shorts video
+  shorts('shorts', 'reelItemRenderer');
+
+  final String name;
+  final String youtubeRenderText;
+  const VideoType(this.name, this.youtubeRenderText);
+}

--- a/lib/src/extensions/helpers_extension.dart
+++ b/lib/src/extensions/helpers_extension.dart
@@ -172,7 +172,10 @@ extension StringUtility2 on String? {
       // Streamed x y ago
       parts = parts.skip(1).toList();
     }
-    assert(parts.length == 3);
+
+    if (parts.length != 3) {
+      return null;
+    }
 
     final qty = int.parse(parts.first);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: youtube_explode_dart
 description: A port in dart of the youtube explode library. Supports several API functions without the need of Youtube API Key.
-version: 2.0.4
+version: 2.1.0
 homepage: https://github.com/Hexer10/youtube_explode_dart
 
 topics:


### PR DESCRIPTION
# Shorts filter implemented
Fix to [this](https://github.com/Hexer10/youtube_explode_dart/issues/268) issue

## What changed?
Now developers can filter only for shorts videos in a channel
Example: 
```dart
 final YoutubeExplode _yt = YoutubeExplode();
await _yt.channels.getUploadsFromPage(
   channel.id,
   VideoSorting.newest,
   videoType: VideoType.shorts, // <= create this setting
)
```