### PR TITLE
fix: Parsing JSON response for shorts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.3.7
+- Fixes JSON parsing for shorts data
+
 ## 2.3.6
 - Update search playlists parsing due to yt changes.
 - Implement >,<,== operators for `VideoResolution`.

--- a/lib/src/channels/video_type.dart
+++ b/lib/src/channels/video_type.dart
@@ -6,7 +6,7 @@ enum VideoType {
   normal('videos', 'videoRenderer'),
 
   /// Youtube shorts video
-  shorts('shorts', 'reelItemRenderer');
+  shorts('shorts', 'shortsLockupViewModel');
 
   final String name;
 

--- a/lib/src/reverse_engineering/pages/channel_upload_page.dart
+++ b/lib/src/reverse_engineering/pages/channel_upload_page.dart
@@ -185,6 +185,12 @@ class _InitialData extends InitialData {
           .get('richItemRenderer')
           ?.get('content')
           ?.get(type.youtubeRenderText);
+      if (type == VideoType.shorts) {
+        video = video
+            ?.get('onTap')
+            ?.get('innertubeCommand')
+            ?.get('reelWatchEndpoint');
+      }
     }
 
     if (video == null) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: youtube_explode_dart
 description: A port in dart of the youtube explode library. Supports several API functions without the need of Youtube API Key.
-version: 2.3.6
+version: 2.3.7
 homepage: https://github.com/Hexer10/youtube_explode_dart
 
 topics:


### PR DESCRIPTION
The JSON response object when retrieving shorts has since changed.