### PR TITLE
fix: Simplify Playlist ID matching logic

### DIFF
--- a/lib/src/playlists/playlist_id.dart
+++ b/lib/src/playlists/playlist_id.dart
@@ -59,18 +59,8 @@ class PlaylistId with _$PlaylistId {
       return true;
     }
 
-    if (!playlistId.startsWith('PL') &&
-        !playlistId.startsWith('RD') &&
-        !playlistId.startsWith('UL') &&
-        !playlistId.startsWith('UU') &&
-        !playlistId.startsWith('PU') &&
-        !playlistId.startsWith('OL') &&
-        !playlistId.startsWith('LL') &&
-        !playlistId.startsWith('FL')) {
-      return false;
-    }
-
-    if (playlistId.length < 13) {
+    // Playlist IDs vary greatly in length, but they are at least 2 characters long
+    if (playlistId.length < 2) {
       return false;
     }
 


### PR DESCRIPTION
For reference: https://github.com/Tyrrrz/YoutubeExplode/blob/f8183ec1899385fb1aa7c557c2f418e1782af369/YoutubeExplode/Playlists/PlaylistId.cs#L25

The playlist URL that was broken: https://youtube.com/playlist?list=LRYRIfTrwZ1zsneNuqfOAw5CvN_Yc54dBpfe1&si=XEgUNf5kXRhZ3mkM

![image](https://github.com/user-attachments/assets/22aa2135-96e7-4057-ac3f-a6d79c9104bd)
