### PR TITLE
fix(search): added if-null check for playlist video count

### DIFF
--- a/lib/src/reverse_engineering/pages/search_page.dart
+++ b/lib/src/reverse_engineering/pages/search_page.dart
@@ -265,7 +265,7 @@ class _InitialData extends InitialData {
           viewModel
               .getJson<String>(
                   'contentImage/collectionThumbnailViewModel/primaryThumbnail/thumbnailViewModel/overlays/0/thumbnailOverlayBadgeViewModel/thumbnailBadges/0/thumbnailBadgeViewModel/text')!
-              .parseInt()!,
+              .parseInt() ?? 0,
           thumbnails
               .map((e) =>
                   Thumbnail(Uri.parse(e['url']), e['height'], e['width']))


### PR DESCRIPTION
This reverts to the previous functionality of checking for `null` and returning `0` when parsing a playlist's video count from the search page. Some auto-generated playlists currently return `Mix`, rather than an actual video count, so in future, perhaps it would make sense to add some sort of indicator to `SearchPlaylist` to denote this, or even return `-1` instead.

Closes #315.