### PR TITLE
fix playlist continuationToken retrieval

### DIFF
--- a/example/video_download_flutter/ios/Flutter/ephemeral/flutter_lldb_helper.py
+++ b/example/video_download_flutter/ios/Flutter/ephemeral/flutter_lldb_helper.py
@@ -1,0 +1,32 @@
+#
+# Generated file, do not edit.
+#
+
+import lldb
+
+def handle_new_rx_page(frame: lldb.SBFrame, bp_loc, extra_args, intern_dict):
+    """Intercept NOTIFY_DEBUGGER_ABOUT_RX_PAGES and touch the pages."""
+    base = frame.register["x0"].GetValueAsAddress()
+    page_len = frame.register["x1"].GetValueAsUnsigned()
+
+    # Note: NOTIFY_DEBUGGER_ABOUT_RX_PAGES will check contents of the
+    # first page to see if handled it correctly. This makes diagnosing
+    # misconfiguration (e.g. missing breakpoint) easier.
+    data = bytearray(page_len)
+    data[0:8] = b'IHELPED!'
+
+    error = lldb.SBError()
+    frame.GetThread().GetProcess().WriteMemory(base, data, error)
+    if not error.Success():
+        print(f'Failed to write into {base}[+{page_len}]', error)
+        return
+
+def __lldb_init_module(debugger: lldb.SBDebugger, _):
+    target = debugger.GetDummyTarget()
+    # Caveat: must use BreakpointCreateByRegEx here and not
+    # BreakpointCreateByName. For some reasons callback function does not
+    # get carried over from dummy target for the later.
+    bp = target.BreakpointCreateByRegex("^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$")
+    bp.SetScriptCallbackFunction('{}.handle_new_rx_page'.format(__name__))
+    bp.SetAutoContinue(True)
+    print("-- LLDB integration loaded --")

--- a/example/video_download_flutter/ios/Flutter/ephemeral/flutter_lldbinit
+++ b/example/video_download_flutter/ios/Flutter/ephemeral/flutter_lldbinit
@@ -1,0 +1,5 @@
+#
+# Generated file, do not edit.
+#
+
+command script import --relative-to-command-file flutter_lldb_helper.py

--- a/example/video_download_flutter/lib/main.dart
+++ b/example/video_download_flutter/lib/main.dart
@@ -1,8 +1,8 @@
 import 'dart:io';
 
-import 'package:downloads_path_provider/downloads_path_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:path/path.dart' as path;
+import 'package:path_provider/path_provider.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:youtube_explode_dart/youtube_explode_dart.dart';
 
@@ -80,9 +80,9 @@ class _MyHomePageState extends State<MyHomePage> {
                 final audio = manifest.audioOnly.last;
 
                 // Build the directory.
-                final dir = await DownloadsPathProvider.downloadsDirectory;
+                final dir = await getDownloadsDirectory();
                 final filePath = path.join(
-                  dir.uri.toFilePath(),
+                  dir!.uri.toFilePath(),
                   '${video.id}.${audio.container.name}',
                 );
 

--- a/example/video_download_flutter/pubspec.yaml
+++ b/example/video_download_flutter/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   cupertino_icons: ^1.0.4
   youtube_explode_dart:
     path: ../../
-  downloads_path_provider: ^0.1.0
+  path_provider:
   permission_handler: ^9.2.0
   path: ^1.8.1
 

--- a/lib/src/reverse_engineering/pages/playlist_page.dart
+++ b/lib/src/reverse_engineering/pages/playlist_page.dart
@@ -157,13 +157,22 @@ class _InitialData extends InitialData {
       ?.getT<String>('text')
       .parseInt();
 
-  late final String? continuationToken =
-      (videosContent ?? playlistVideosContent)
-          ?.firstWhereOrNull((e) => e['continuationItemRenderer'] != null)
-          ?.get('continuationItemRenderer')
-          ?.get('continuationEndpoint')
-          ?.get('continuationCommand')
-          ?.getT<String>('token');
+  String? get continuationToken {
+    final continuationEndpoint = (videosContent ?? playlistVideosContent)
+        ?.firstWhereOrNull((e) => e['continuationItemRenderer'] != null)
+        ?.get('continuationItemRenderer')
+        ?.get('continuationEndpoint');
+
+    return continuationEndpoint
+            ?.get('continuationCommand')
+            ?.getT<String>('token') ??
+        continuationEndpoint
+            ?.get('commandExecutorCommand')
+            ?.getList('commands')
+            ?.firstWhereOrNull((e) => e['continuationCommand'] != null)
+            ?.get('continuationCommand')
+            ?.getT<String>('token');
+  }
 
   List<JsonMap>? get playlistVideosContent =>
       root

--- a/test/playlist_test.dart
+++ b/test/playlist_test.dart
@@ -56,6 +56,17 @@ void main() {
     expect(videos.length, greaterThan(100));
   });
 
+  test('Get a shit ton of items from a playlist', () async {
+    final videos = await yt!.playlists
+        .getVideos(
+          PlaylistId(
+            'https://www.youtube.com/playlist?list=PLI_eFW8NAFzYAXZ5DrU6E6mQ_XfhaLBUX',
+          ),
+        )
+        .toList();
+    expect(videos.length, greaterThan(3500));
+  }, timeout: Timeout(Duration(minutes: 3)));
+
   group('Get videos in any playlist', () {
     for (final val in {
       PlaylistId('PLI5YfMzCfRtZ8eV576YoY3vIYrHjyVm_e'),


### PR DESCRIPTION
Fix #344 

The new test added has 3900+ unique video
this library seems to be able to retrieve up-to 3954 after which YouTube does not send a continuationToken.