### PR TITLE
YoutubeHttpClient: expose defaultHeaders to be overridable

### DIFF
--- a/lib/src/reverse_engineering/youtube_http_client.dart
+++ b/lib/src/reverse_engineering/youtube_http_client.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:collection/collection.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
 
@@ -22,7 +23,7 @@ class YoutubeHttpClient extends http.BaseClient {
 
   bool get closed => _closed;
 
-  static const Map<String, String> _defaultHeaders = {
+  static const Map<String, String> defaultHeaders = {
     'user-agent':
         'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.18 Safari/537.36',
     'cookie': 'CONSENT=YES+cb',
@@ -30,6 +31,9 @@ class YoutubeHttpClient extends http.BaseClient {
         'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
     'accept-language': 'en-US,en;q=0.5',
   };
+
+  /// For any custom YoutubeHttpClient to override headers easily
+  Map<String, String> get headers => defaultHeaders;
 
   /// Initialize an instance of [YoutubeHttpClient]
   YoutubeHttpClient([http.Client? httpClient])
@@ -345,9 +349,9 @@ class YoutubeHttpClient extends http.BaseClient {
     if (_closed) throw HttpClientClosedException();
 
     // Apply default headers if they are not already present
-    _defaultHeaders.forEach((key, value) {
+    headers.forEach((key, value) {
       if (request.headers[key] == null) {
-        request.headers[key] = _defaultHeaders[key]!;
+        request.headers[key] = headers[key]!;
       }
     });
 


### PR DESCRIPTION
Add cookies and shit without overriding send()