### PR TITLE
Add androidSdkless client to fix 403 errors on audio-only streams

### DIFF
--- a/lib/src/videos/streams/stream_client.dart
+++ b/lib/src/videos/streams/stream_client.dart
@@ -65,7 +65,7 @@ class StreamClient {
         'ytClients cannot be an empty list');
 
     videoId = VideoId.fromString(videoId);
-    final clients = ytClients ?? [YoutubeApiClient.android];
+    final clients = ytClients ?? [YoutubeApiClient.androidSdkless];
 
     if (_jsChallengeSolver != null && ytClients == null) {
       clients.add(YoutubeApiClient.tv);

--- a/lib/src/videos/youtube_api_client.dart
+++ b/lib/src/videos/youtube_api_client.dart
@@ -40,12 +40,34 @@ class YoutubeApiClient {
 
   /// This provides also muxed streams but seems less reliable than [ios].
   /// If you require an android client use [androidVr] instead.
+  /// Note: This client includes androidSdkVersion which may require PO Token.
+  /// Consider using [androidSdkless] instead for better compatibility.
   static const android = YoutubeApiClient({
     'context': {
       'client': {
         'clientName': 'ANDROID',
         'clientVersion': '20.10.38',
         'androidSdkVersion': 30,
+        'userAgent':
+            'com.google.android.youtube/20.10.38 (Linux; U; Android 11) gzip',
+        'hl': 'en',
+        'timeZone': 'UTC',
+        'utcOffsetMinutes': 0,
+        'osName': 'Android',
+        'osVersion': '11',
+      },
+    },
+  }, 'https://www.youtube.com/youtubei/v1/player?prettyPrint=false');
+
+  /// Android client without androidSdkVersion field.
+  /// This client doesn't require a PO Token and provides better compatibility
+  /// for streaming audio/video without 403 errors.
+  /// Based on yt-dlp's android_sdkless client.
+  static const androidSdkless = YoutubeApiClient({
+    'context': {
+      'client': {
+        'clientName': 'ANDROID',
+        'clientVersion': '20.10.38',
         'userAgent':
             'com.google.android.youtube/20.10.38 (Linux; U; Android 11) gzip',
         'hl': 'en',


### PR DESCRIPTION
Audio-only streams return 403 while muxed streams work. Root cause: the `android` client includes `androidSdkVersion` which triggers YouTube's PO Token requirement.

### Changes

- **Added `YoutubeApiClient.androidSdkless`** — Android client without `androidSdkVersion` field, based on yt-dlp's working implementation
- **Changed default client** from `android` to `androidSdkless` in `StreamClient.getManifest()`

### Reference

From [yt-dlp's _base.py](https://github.com/yt-dlp/yt-dlp/blob/master/yt_dlp/extractor/youtube/_base.py):
```python
# Doesn't require a PoToken for some reason
'android_sdkless': {
    'INNERTUBE_CONTEXT': {
        'client': {
            'clientName': 'ANDROID',
            'clientVersion': '20.10.38',
            # Note: no androidSdkVersion
            'userAgent': 'com.google.android.youtube/20.10.38 (Linux; U; Android 11) gzip',
            ...
        },
    },
    ...
}
```

The original `android` client is preserved for users who need it explicitly.