### PR TITLE
Add ChannelId fallback for collaborative videos

### DIFF
--- a/lib/src/playlists/playlist_client.dart
+++ b/lib/src/playlists/playlist_client.dart
@@ -26,7 +26,7 @@ class PlaylistClient {
       response.title ?? '',
       response.author ?? '',
       response.description ?? '',
-      ThumbnailSet(id.value),
+      ThumbnailSet(response.videos.firstOrNull?.id ?? id.value),
       Engagement(response.viewCount ?? 0, null, null),
       response.videoCount,
     );

--- a/lib/src/reverse_engineering/pages/playlist_page.dart
+++ b/lib/src/reverse_engineering/pages/playlist_page.dart
@@ -246,22 +246,43 @@ class _Video {
           .parseRuns() ??
       '';
 
-  String get channelId =>
-      root
-          .get('ownerText')
-          ?.getList('runs')
-          ?.firstOrNull
-          ?.get('navigationEndpoint')
-          ?.get('browseEndpoint')
-          ?.getT<String>('browseId') ??
-      root
-          .get('shortBylineText')
-          ?.getList('runs')
-          ?.firstOrNull
-          ?.get('navigationEndpoint')
-          ?.get('browseEndpoint')
-          ?.getT<String>('browseId') ??
-      '';
+  String get channelId {
+    return root
+            .get('ownerText')
+            ?.getList('runs')
+            ?.firstOrNull
+            ?.get('navigationEndpoint')
+            ?.get('browseEndpoint')
+            ?.getT<String>('browseId') ??
+        root
+            .get('shortBylineText')
+            ?.getList('runs')
+            ?.firstOrNull
+            ?.get('navigationEndpoint')
+            ?.get('browseEndpoint')
+            ?.getT<String>('browseId') ??
+        root
+            .get('shortBylineText')
+            ?.getList('runs')
+            ?.firstOrNull
+            ?.get('navigationEndpoint')
+            ?.get('showDialogCommand')
+            ?.get('panelLoadingStrategy')
+            ?.get('inlineContent')
+            ?.get('dialogViewModel')
+            ?.get('customContent')
+            ?.get('listViewModel')
+            ?.getList('listItems')
+            ?.firstOrNull
+            ?.get('listItemViewModel')
+            ?.get('rendererContext')
+            ?.get('commandContext')
+            ?.get('onTap')
+            ?.get('innertubeCommand')
+            ?.get('browseEndpoint')
+            ?.getT<String>('browseId') ??
+        '';
+  }
 
   String get title => root.get('title')?.getList('runs')?.parseRuns() ?? '';
 

--- a/test/playlist_test.dart
+++ b/test/playlist_test.dart
@@ -78,4 +78,11 @@ void main() {
         .toList();
     expect(videos.length, greaterThan(100));
   });
+
+  test('Get videos of playlist with collaborative video', () async {
+    final videos = await yt!.playlists
+        .getVideos('PLjp0AEEJ0-fGKG_3skl0e1FQlJfnx-TJz')
+        .toList();
+    expect(videos.any((v) => v.id.value == '32sPcsb9ClQ'), true);
+  });
 }


### PR DESCRIPTION
fix #370

It picks the first channel id from a list of channels